### PR TITLE
Fix buffer overflow issue

### DIFF
--- a/main.c
+++ b/main.c
@@ -6,7 +6,7 @@ int main()
     char name[64];
 
     printf("Enter your name:\n");
-    fgets(name, sizeof(name) + 32, stdin);
+    fgets(name, sizeof(name), stdin);
 
     // Remove the trailing newline character if present
     name[strcspn(name, "\n")] = '\0';

--- a/main.c
+++ b/main.c
@@ -3,10 +3,10 @@
 
 int main()
 {
-    char name[64];
+    char name[128];
 
     printf("Enter your name:\n");
-    fgets(name, sizeof(name) + 32, stdin);
+    fgets(name, sizeof(name), stdin);
 
     // Remove the trailing newline character if present
     name[strcspn(name, "\n")] = '\0';


### PR DESCRIPTION
## Fix buffer overflow issue by adjusting input buffer size and fgets usage

### Description
This pull request addresses the issue of a segmentation fault occurring when a name longer than 80 characters is entered into the program. The fix involves increasing the buffer size for the `name` variable and correcting the usage of the `fgets` function to prevent buffer overflow.

### Changes Made
- Increased the buffer size for the `name` variable from 64 to 128 characters.
- Corrected the `fgets` function to use `sizeof(name)` instead of `sizeof(name) + 32`.

### Issue Reference
This pull request fixes issue [#6](https://github.com/coding-agent-contributor/simple-hello/issues/6).

### Testing
- Manually tested the program by entering names of various lengths, including names longer than 80 characters, to ensure no segmentation fault occurs.
- Verified that the program correctly handles input and removes the trailing newline character.

### Notes
- The changes are limited to the `main.c` file.
- The fix ensures that the program can safely handle longer input without causing a segmentation fault.
